### PR TITLE
added None url to allow preview

### DIFF
--- a/app/stitcher/stitch.py
+++ b/app/stitcher/stitch.py
@@ -59,7 +59,7 @@ def preview(handler, width, height):
     """
     Preview camera stream
     """
-    handler.stitch_feeds(False, None, width, height)
+    handler.stitch_feeds(False, None, width, height, None)
 
 def stream_and_record(handler, width, height, dest, url):
     """


### PR DESCRIPTION
Preview was broken because there were not enough arguments. Fixed with None pass to url.